### PR TITLE
Set services in the constructor. Closes #29

### DIFF
--- a/Command/ChangeChannelsTopicCommand.php
+++ b/Command/ChangeChannelsTopicCommand.php
@@ -2,14 +2,25 @@
 
 namespace DZunke\SlackBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use DZunke\SlackBundle\Slack\Channels;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ChangeChannelsTopicCommand extends ContainerAwareCommand
+class ChangeChannelsTopicCommand extends Command
 {
+    /**
+     * @var Channels
+     */
+    private $channels;
+
+    public function __construct(Channels $channels)
+    {
+        $this->channels = $channels;
+        parent::__construct();
+    }
 
     protected function configure()
     {
@@ -25,14 +36,13 @@ class ChangeChannelsTopicCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         try {
-            $channels = $this->getContainer()->get('dz.slack.channels');
             if ($input->getOption('discover')) {
-                $channelId = $channels->getId($input->getArgument('channel'));
+                $channelId = $this->channels->getId($input->getArgument('channel'));
             } else {
                 $channelId = $input->getArgument('channel');
             }
 
-            $response = $channels->setTopic(
+            $response = $this->channels->setTopic(
                 $channelId,
                 $input->getArgument('topic')
             );

--- a/Command/DebugCommand.php
+++ b/Command/DebugCommand.php
@@ -3,15 +3,14 @@
 namespace DZunke\SlackBundle\Command;
 
 use DZunke\SlackBundle\Slack\Client;
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Helper\TableSeparator;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class DebugCommand extends ContainerAwareCommand
+class DebugCommand extends Command
 {
-
     /**
      * @var InputInterface
      */
@@ -27,6 +26,12 @@ class DebugCommand extends ContainerAwareCommand
      */
     protected $client;
 
+    public function __construct(Client $client)
+    {
+        $this->client = $client;
+        parent::__construct();
+    }
+
     protected function configure()
     {
         $this
@@ -40,7 +45,6 @@ class DebugCommand extends ContainerAwareCommand
     {
         $this->input  = $input;
         $this->output = $output;
-        $this->client = $this->getContainer()->get('dz.slack.client');
 
         $config = $this->getContainer()->getParameter('d_zunke_slack.config');
 

--- a/Command/MessageCommand.php
+++ b/Command/MessageCommand.php
@@ -2,13 +2,21 @@
 
 namespace DZunke\SlackBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use DZunke\SlackBundle\Slack\Messaging;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class MessageCommand extends ContainerAwareCommand
+class MessageCommand extends Command
 {
+    private $messenger;
+
+    public function __construct(Messaging $messenger)
+    {
+        $this->messenger = $messenger;
+        parent::__construct();
+    }
 
     protected function configure()
     {
@@ -24,8 +32,7 @@ class MessageCommand extends ContainerAwareCommand
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         try {
-            $messenger = $this->getContainer()->get('dz.slack.messaging');
-            $response  = $messenger->message(
+            $response = $this->messenger->message(
                 $input->getArgument('channel'),
                 $input->getArgument('message'),
                 $input->getArgument('username')

--- a/Command/UsersCommand.php
+++ b/Command/UsersCommand.php
@@ -2,14 +2,26 @@
 
 namespace DZunke\SlackBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use DZunke\SlackBundle\Slack\Users;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class UsersCommand extends ContainerAwareCommand
+class UsersCommand extends Command
 {
+    /**
+     * @var Users
+     */
+    private $api;
+
+    public function __construct(Users $users)
+    {
+        $this->api = $users;
+        parent::__construct();
+    }
+
     protected function configure()
     {
         $this
@@ -26,20 +38,18 @@ class UsersCommand extends ContainerAwareCommand
         $formatter = $this->getHelper('formatter');
 
         try {
-            $api = $this->getContainer()->get('dz.slack.users');
-
             if ($input->getOption('only-active')) {
-                $response = $api->getActiveUsers();
+                $response = $this->api->getActiveUsers();
             } elseif ($input->getOption('only-deleted')) {
-                $response = $api->getDeletedUsers();
+                $response = $this->api->getDeletedUsers();
             } elseif ($input->getOption('user')) {
-                $response = $api->getUser($input->getOption('user'));
+                $response = $this->api->getUser($input->getOption('user'));
 
                 if (is_array($response)) {
                     $response = [$response['name'] => $response];
                 }
             } else {
-                $response = $api->getUsers();
+                $response = $this->api->getUsers();
             }
 
             if (empty($response)) {

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -23,12 +23,21 @@ services:
         arguments: ["@dz.slack.client"]
 
     DZunke\SlackBundle\Command\BotMessagingCommand:
+        arguments: ["@dz.slack.channels", "@event_dispatcher"]
         tags: ['console.command']
+
     DZunke\SlackBundle\Command\ChangeChannelsTopicCommand:
+        arguments: ["@dz.slack.channels"]
         tags: ['console.command']
+
     DZunke\SlackBundle\Command\DebugCommand:
+        arguments: ["@dz.slack.client"]
         tags: ['console.command']
+
     DZunke\SlackBundle\Command\MessageCommand:
+        arguments: ["@dz.slack.messaging"]
         tags: ['console.command']
+
     DZunke\SlackBundle\Command\UsersCommand:
+        arguments: ["@dz.slack.users"]
         tags: ['console.command']


### PR DESCRIPTION
Can also remove the use of ContainerAwareCommand, and instead use
Symfony\Component\Console\Command\Command

This pull-request builds on top of the #28 branch